### PR TITLE
scylla-artifacts.py: Adjust io settings before the test

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -204,6 +204,11 @@ class ScyllaArtifactSanity(Test):
                            '(see logs for details)' %
                            os.path.basename(pkg))
 
+        # Let's use very low/conservative io config numbers
+        # as a workaround for now.
+        seastar_io_conf = 'SEASTAR_IO="--max-io-requests=1 --num-io-queues=1"'
+        process.run('echo %s > /etc/scylla.d/io.conf' % seastar_io_conf, shell=True)
+        process.run('touch /etc/scylla/io_configured')
         if not ami:
             self.start_services()
 


### PR DESCRIPTION
Sometimes we might run on slow disks, so let's unconditionally
skip the iotune setup process and use the most conservative
settings possible, at least for now.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>