### PR TITLE
scylla-artifacts.py: Increase the timeout for scylla DB to be up

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -136,7 +136,7 @@ class ScyllaArtifactSanity(Test):
         return not network.is_port_free(9042, 'localhost')
 
     def wait_services_up(self):
-        service_start_timeout = 120
+        service_start_timeout = 3600
         output = wait.wait_for(func=self._scylla_service_is_up,
                                timeout=service_start_timeout, step=5)
         if output is None:


### PR DESCRIPTION
Since now with iotune the startup time is a lot longer than
what it used to be.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>