### PR TITLE
scylla-artifacts.py: Reduce wait for scylla service

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -136,7 +136,7 @@ class ScyllaArtifactSanity(Test):
         return not network.is_port_free(9042, 'localhost')
 
     def wait_services_up(self):
-        service_start_timeout = 3600
+        service_start_timeout = 900
         output = wait.wait_for(func=self._scylla_service_is_up,
                                timeout=service_start_timeout, step=5)
         if output is None:


### PR DESCRIPTION
We can't afford to wait 1 hour by default to see if scylla
server is up.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>