### PR TITLE
scylla-artifacts.py: Adjust io queue params

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -207,7 +207,7 @@ class ScyllaArtifactSanity(Test):
         if not ami:
             # Let's use very low/conservative io config numbers
             # as a workaround for now.
-            process.run('echo "SEASTAR_IO=\'--max-io-requests=1 --num-io-queues=1\'" | sudo tee /etc/scylla.d/io.conf', shell=True)
+            process.run('echo "SEASTAR_IO=\'--max-io-requests=4 --num-io-queues=1\'" | sudo tee /etc/scylla.d/io.conf', shell=True)
             process.run('touch /etc/scylla/io_configured')
             self.start_services()
 


### PR DESCRIPTION
The very conservative settings our testing uses is now
causing problems with the io queue params sanity check:

Reason found: I/O Queue capacity for this shard is too low (1, minimum 4 expected)

So let's bump the params a little so we don't have this
problem.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>