### PR TITLE
scylla-artifacts.py: Use uniform key distribution on mixed workload

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -265,8 +265,9 @@ class ScyllaArtifactSanity(Test):
         result_populate = process.run(stress_populate)
         check_output(result_populate)
         stress_mixed = ('%s mixed duration=1m -mode cql3 native '
-                        '-rate threads=10' % cassandra_stress_exec)
-        result_mixed = process.run(stress_mixed)
+                        '-rate threads=10 -pop dist=UNIFORM\(1..10000\)' %
+                        cassandra_stress_exec)
+        result_mixed = process.run(stress_mixed, shell=True)
         check_output(result_mixed)
 
     def get_scylla_logs(self):


### PR DESCRIPTION
Let's use an uniform key distribution to avoid the mixed workload
not finding the right keys.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>