### PR TITLE
scylla-artifacts.py: Use uniform distribution on populate and mixed w…

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -260,12 +260,12 @@ class ScyllaArtifactSanity(Test):
                 if 'java.io.IOException' in line:
                     self.fail('cassandra-stress: %s' % line.strip())
         cassandra_stress_exec = path.find_command('cassandra-stress')
-        stress_populate = ('%s write n=10000 -mode cql3 native' %
+        stress_populate = ('%s write n=10000 -mode cql3 native -pop dist=SEQ\(1..10000\)' %
                            cassandra_stress_exec)
         result_populate = process.run(stress_populate)
         check_output(result_populate)
         stress_mixed = ('%s mixed duration=1m -mode cql3 native '
-                        '-rate threads=10 -pop dist=UNIFORM\(1..10000\)' %
+                        '-rate threads=10 -pop dist=SEQ\(1..10000\)' %
                         cassandra_stress_exec)
         result_mixed = process.run(stress_mixed, shell=True)
         check_output(result_mixed)


### PR DESCRIPTION
…orkloads

So that we avoid problems on the 2nd step.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>