### PR TITLE
scylla-artifacts.py: Wait until system upgrade is actually done

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -112,7 +112,8 @@ class ScyllaInstallGeneric(object):
         self.srv_manager = ScyllaServiceManager()
 
     def run(self):
-        self.sw_manager.upgrade()
+        wait.wait_for(self.sw_manager.upgrade, timeout=300, step=30,
+                      text="Wait until system is up to date...")
         if self.mode == 'ci':
             get_packages = self.setup_ci
         else:


### PR DESCRIPTION
Ubuntu may sometimes have a background apt upgrade thread,
causing the test triggered update to not work. Let's keep
trying every 30 seconds until the .upgrade() method returns
True, this will give the background thread time to finish.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>