### PR TITLE
report uuid of test node to ScyllaDB

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -261,6 +261,16 @@ class ScyllaInstallGeneric(object):
                          '(see logs for details)' % os.path.basename(pkg))
                 raise InstallPackageError(e_msg)
         process.run('/usr/lib/scylla/scylla_io_setup', shell=True)
+
+        uuid_path = '/var/lib/scylla-housekeeping/housekeeping.uuid'
+        report_status_path = '/etc/scylla.d/housekeeping.uuid.reported'
+        cmd = 'curl "https://i6a5h9l1kl.execute-api.us-east-1.amazonaws.com/prod/check_version?uu=%s&mark=scylla"'
+        if os.path.exists(uuid_path) and not os.path.exists(
+                                             report_status_path):
+            with open(uuid_path) as uuid_file:
+                uuid = uuid_file.read().strip()
+            process.run(cmd % uuid, shell=True, verbose=True)
+            process.run('sudo touch %s' % report_status_path)
         self.srv_manager.start_services()
         self.srv_manager.wait_services_up()
 


### PR DESCRIPTION
We use uuid to identify each Scylla db node,
this patch reports uuid of test node to ScyllaDB,
it helps to identify real users.