### PR TITLE
ami: report uuid after service is up

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -36,6 +36,22 @@ def _search_scriptlet_failure(result):
             SCRIPTLET_FAILURE_LIST.append(pkg)
 
 
+def _try_report_uuid():
+    log = logging.getLogger('avocado.test')
+    uuid_path = '/var/lib/scylla-housekeeping/housekeeping.uuid'
+    mark_path = '/var/lib/scylla-housekeeping/housekeeping.uuid.marked'
+    cmd = 'curl "https://i6a5h9l1kl.execute-api.us-east-1.amazonaws.com/prod/check_version?uu=%s&mark=scylla"'
+    wait.wait_for(lambda: os.path.exists(uuid_path), timeout=30, step=5,
+                  text='Waiting for housekeeping.uuid generated')
+
+    if os.path.exists(uuid_path) and not os.path.exists(mark_path):
+        with open(uuid_path) as uuid_file:
+            uuid = uuid_file.read().strip()
+        log.debug('housekeeping.uuid is %s' % uuid)
+        process.run(cmd % uuid, shell=True, verbose=True)
+        process.run('sudo -u scylla touch %s' % mark_path, verbose=True)
+
+
 class ScyllaYumBackend(YumBackend):
 
     def install(self, name):
@@ -264,19 +280,7 @@ class ScyllaInstallGeneric(object):
 
         self.srv_manager.start_services()
         self.srv_manager.wait_services_up()
-
-        uuid_path = '/var/lib/scylla-housekeeping/housekeeping.uuid'
-        mark_path = '/var/lib/scylla-housekeeping/housekeeping.uuid.marked'
-        cmd = 'curl "https://i6a5h9l1kl.execute-api.us-east-1.amazonaws.com/prod/check_version?uu=%s&mark=scylla"'
-        wait.wait_for(lambda: os.path.exists(uuid_path), timeout=30, step=5,
-                      text='Waiting for housekeeping.uuid generated')
-
-        if os.path.exists(uuid_path) and not os.path.exists(mark_path):
-            with open(uuid_path) as uuid_file:
-                uuid = uuid_file.read().strip()
-            self.log.debug('housekeeping.uuid is %s' % uuid)
-            process.run(cmd % uuid, shell=True, verbose=True)
-            process.run('sudo -u scylla touch %s' % mark_path, verbose=True)
+        _try_report_uuid()
 
 
 class ScyllaInstallDebian(ScyllaInstallGeneric):
@@ -460,6 +464,7 @@ class ScyllaInstallAMI(ScyllaInstallGeneric):
     def run(self):
         self.log.info("Testing AMI, let's just check if the DB is up...")
         self.srv_manager.wait_services_up()
+        _try_report_uuid()
 
 
 class ScyllaArtifactSanity(Test):


### PR DESCRIPTION
ScyllaInstallAMI implemented its own run() function,
currently AMI tests still don't report uuid, this
patch supported it.