### PR TITLE
ubuntu 14.04: enable openjdk repo for installing scylla 1.7 and later

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -4,6 +4,7 @@ import os
 import re
 import logging
 import threading
+from pkg_resources import parse_version
 
 from avocado import Test
 from avocado import main
@@ -293,6 +294,14 @@ class ScyllaInstallUbuntu1404(ScyllaInstallDebian):
     def setup_ci(self):
         process.run('sudo curl %s -o %s' % (self.sw_repo_src, self.sw_repo_dst),
                     shell=True)
+        process.run('sudo apt-get update')
+        result = process.run('sudo apt-cache show scylla')
+        ver = re.findall("Version: (.*)", result.stdout)[0]
+        if parse_version(ver) >= parse_version('1.7~rc0'):
+            process.run('sudo add-apt-repository -y ppa:openjdk-r/ppa', shell=True)
+            process.run('sudo apt-get update')
+            process.run('sudo apt-get install -y openjdk-8-jre-headless', shell=True)
+            process.run('sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java', shell=True)
         self.sw_manager.upgrade()
         return ['scylla']
 


### PR DESCRIPTION
In scylla 1.7, scylla-jmx and scylla-tools depend on openjdk packages.
This patch enables openjdk repo for install scylla 1.7 and later.

https://github.com/scylladb/scylla/issues/2091