### PR TITLE
full scylla setup

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -275,7 +275,7 @@ class ScyllaInstallGeneric(object):
                 e_msg = ('Package %s could not be installed '
                          '(see logs for details)' % os.path.basename(pkg))
                 raise InstallPackageError(e_msg)
-        process.run('/usr/lib/scylla/scylla_io_setup', shell=True)
+        process.run('yes "" | sudo /usr/lib/scylla/scylla_setup', shell=True)
 
         self.srv_manager.start_services()
         self.srv_manager.wait_services_up()


### PR DESCRIPTION
Currently we only setup scylla with scylla_io_setup script, this patch changed to execute 'scylla_setup' with all default options.