### PR TITLE
Revert "full scylla setup"

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -275,7 +275,7 @@ class ScyllaInstallGeneric(object):
                 e_msg = ('Package %s could not be installed '
                          '(see logs for details)' % os.path.basename(pkg))
                 raise InstallPackageError(e_msg)
-        process.run('yes "" | sudo /usr/lib/scylla/scylla_setup', shell=True)
+        process.run('/usr/lib/scylla/scylla_io_setup', shell=True)
 
         self.srv_manager.start_services()
         self.srv_manager.wait_services_up()


### PR DESCRIPTION
This reverts commit c10f4d7de68f35f9c340d847d3e266a6b4a970c6.
It doesn't work in raid setup on Ubuntu without XFS disk.