### PR TITLE
RFC: skip repeated raid and node_exporter setup

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -280,7 +280,10 @@ class ScyllaInstallGeneric(object):
         setup_cmd = 'sudo /usr/lib/scylla/scylla_setup --nic eth0'
         result = process.run('ls /dev/[hvs]db', shell=True, ignore_status=True)
         devlist = result.stdout.split()
-        if devlist:
+
+        with open('/proc/mounts', 'r') as f:
+            mounts_content = f.read()
+        if devlist and '/var/lib/scylla' not in mounts_content:
             setup_cmd += ' --disks %s' % devlist[-1]
         else:
             setup_cmd += ' --no-raid-setup'

--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -288,6 +288,9 @@ class ScyllaInstallGeneric(object):
         else:
             setup_cmd += ' --no-raid-setup'
 
+        if os.path.exists('/usr/bin/node_exporter'):
+            setup_cmd += ' --no-node-exporter'
+
         # disable cpuscaling setup for known issue:
         # https://github.com/scylladb/scylla/issues/2051
         with open('/usr/lib/scylla/scylla_setup', 'r') as f:


### PR DESCRIPTION
Sometimes scylla_setup executes good, but the service fails to start for scylla bug. Then it will repeatedly setup scylla.

Let's skip repeated raid and node_exporter setup, then the second scylla_setup won't fail.