### PR TITLE
only compare major version

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -318,8 +318,8 @@ class ScyllaInstallUbuntu1404(ScyllaInstallDebian):
                     shell=True)
         process.run('sudo apt-get update')
         result = process.run('sudo apt-cache show scylla')
-        ver = re.findall("Version: (.*)", result.stdout)[0]
-        if parse_version(ver) >= parse_version('1.7~rc0'):
+        ver = re.findall("Version: ([\d.]+)", result.stdout)[0].strip('.')
+        if parse_version(ver) >= parse_version('1.7'):
             process.run('sudo apt-get install software-properties-common -y', shell=True)
             process.run('sudo add-apt-repository -y ppa:openjdk-r/ppa', shell=True)
             process.run('sudo apt-get update')


### PR DESCRIPTION
We use the full version info which is got from `apt-cache show scylla` for comparing. 
Sometimes the wrong in comparing version causes java8 isn't installed as expected.
Let's just compare the major part of version.