### PR TITLE
redirect output of docker run to /dev/null

### DIFF
--- a/scylla_docker.py
+++ b/scylla_docker.py
@@ -54,7 +54,7 @@ class ScyllaDocker(object):
 
     def create_cluster(self):
         log.debug('create cluster')
-        self._cmd('run --name {} -d {}'.format(self._seed_name, self._image))
+        self._cmd('run --name {} -d {} >/dev/null'.format(self._seed_name, self._image))
         self.nodes.append(self._seed_name)
         if self._node_cnt > 1:
             seed_ip = self.get_node_ip(self._seed_name)


### PR DESCRIPTION
There is an issue to run the docker run for images that aren't locally.
The run command doesn't have a silent option (yet), so when it tries to download the image, there are ugly progress bars that Jenkins doesn't like.