### PR TITLE
private_repo: correct the repo urls

### DIFF
--- a/scylla_private_repo.yaml
+++ b/scylla_private_repo.yaml
@@ -1,13 +1,13 @@
 distro: !mux
     centos7:
         name: 'centos7'
-        repo_url: 'https://repositories.scylladb.com/scylla/repo/amos-test/centos/scylla-1.7.repo'
+        repo_url: 'https://repositories.scylladb.com/scylla/repo/amos-test/centos/scylladb-1.7.repo'
         pkginfo_url: 'https://repositories.scylladb.com/scylla/scylladb/amos-test/rpm/scylla/centos/scylladb-1.7/7Server/x86_64/repodata/repomd.xml'
         redirect_url: 'http://downloads.scylladb.com/rpm/centos/scylladb-1.7/7Server/x86_64/repodata/repomd.xml'
 
     ubuntu1404:
         name: 'ubuntu1404'
-        repo_url: 'https://repositories.scylladb.com/scylla/repo/amos-test/ubuntu/scylla-1.7-trusty.list'
+        repo_url: 'https://repositories.scylladb.com/scylla/repo/amos-test/ubuntu/scylladb-1.7-trusty.list'
         pkginfo_url: 'https://repositories.scylladb.com/scylla/scylladb/amos-test/deb/ubuntu/dists/trusty/scylladb-1.7/multiverse/binary-amd64/Packages.gz'
         redirect_url: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/dists/trusty/scylladb-1.7/multiverse/binary-amd64/Packages.gz'
 


### PR DESCRIPTION
Aws backend added strict checking for the version string,
this patch corrected the urls to make the valid.