### PR TITLE
apt backend: install apt-transport-https

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -69,6 +69,10 @@ class ScyllaDnfBackend(DnfBackend):
 
 class ScyllaAptBackend(AptBackend):
 
+    def __init__(self):
+        process.run('sudo apt-get install -y apt-transport-https', shell=True)
+        super(ScyllaAptBackend, self).__init__()
+
     def upgrade(self, name=None):
         """
         Upgrade all packages of the system with eventual new versions.


### PR DESCRIPTION
Running 'sudo curl https://repositories.scylladb.com/scylla/repo/xxxx/debian/scylladb-2.0-jessie.list ...
Running 'sudo apt-get update'
[stderr] E: The method driver /usr/lib/apt/methods/https could not be found.