### PR TITLE
private-repo: add some prefix of repo content

### DIFF
--- a/scylla_private_repo.py
+++ b/scylla_private_repo.py
@@ -73,7 +73,8 @@ class PrivateRepo(object):
 class RHELPrivateRepo(PrivateRepo):
     def __init__(self, sw_repo, pkginfo_url, redirect_url):
         super(RHELPrivateRepo, self).__init__(sw_repo, pkginfo_url, redirect_url)
-        self.body_prefix = ['[scylla', 'name=', 'baseurl=', 'enabled=', 'gpgcheck=']
+        self.body_prefix = ['[scylla', 'name=', 'baseurl=', 'enabled=', 'gpgcheck=', 'type=',
+                            'skip_if_unavailable=', 'gpgkey=', 'repo_gpgcheck=', 'enabled_metadata=']
 
 
 class DebianPrivateRepo(PrivateRepo):


### PR DESCRIPTION
There are some new parameters in scylla 2.1 repo, this patch updated
the prefix list.

Problem: New [scylla-private-repo jobs](http://jenkins.cloudius-systems.com/job/scylla-private-repo-test/label=gce3,scylla_version=scylladb-2.1/) of scylla-2.1 failed for repo checking.

[Test job](http://jenkins.cloudius-systems.com/job/scylla-private-repo-test-amos-clone/label=gce3,scylla_version=scylladb-2.1/2/console) of this PR is good.