### PR TITLE
Fix hkeeping UUID in config file

### DIFF
--- a/scylla_private_repo.yaml
+++ b/scylla_private_repo.yaml
@@ -2,25 +2,25 @@ distro: !mux
     centos7:
         name: 'centos7'
         sw_repo: 'https://repositories.scylladb.com/scylla/repo/amos-test-centos/centos/scylladb-1.7.repo'
-        pkginfo_url: 'https://repositories.scylladb.com/scylla/scylladb/amos-test/rpm/scylla/centos/scylladb-1.7/7Server/x86_64/repodata/repomd.xml'
+        pkginfo_url: 'https://repositories.scylladb.com/scylla/scylladb/amos-test-centos/rpm/scylla/centos/scylladb-1.7/7Server/x86_64/repodata/repomd.xml'
         redirect_url: 'http://downloads.scylladb.com/rpm/centos/scylladb-1.7/7Server/x86_64/repodata/repomd.xml'
 
     ubuntu1404:
         name: 'ubuntu1404'
         sw_repo: 'https://repositories.scylladb.com/scylla/repo/amos-test-ubuntu14/ubuntu/scylladb-1.7-trusty.list'
-        pkginfo_url: 'https://repositories.scylladb.com/scylla/scylladb/amos-test/deb/ubuntu/dists/trusty/scylladb-1.7/multiverse/binary-amd64/Packages.gz'
+        pkginfo_url: 'https://repositories.scylladb.com/scylla/scylladb/amos-test-ubuntu14/deb/ubuntu/dists/trusty/scylladb-1.7/multiverse/binary-amd64/Packages.gz'
         redirect_url: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/dists/trusty/scylladb-1.7/multiverse/binary-amd64/Packages.gz'
 
     ubuntu1604:
         name: 'ubuntu1604'
         sw_repo: 'https://repositories.scylladb.com/scylla/repo/amos-test-ubuntu16/ubuntu/scylladb-1.7-xenial.list'
-        pkginfo_url: 'https://repositories.scylladb.com/scylla/scylladb/amos-test/deb/ubuntu/dists/xenial/scylladb-1.7/multiverse/binary-amd64/Packages.gz'
+        pkginfo_url: 'https://repositories.scylladb.com/scylla/scylladb/amos-test-ubuntu16/deb/ubuntu/dists/xenial/scylladb-1.7/multiverse/binary-amd64/Packages.gz'
         redirect_url: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/dists/xenial/scylladb-1.7/multiverse/binary-amd64/Packages.gz'
 
     debian8:
         name: 'debian8'
         sw_repo: 'https://repositories.scylladb.com/scylla/repo/amos-test-debian8/debian/scylladb-1.7-jessie.list'
-        pkginfo_url: 'https://repositories.scylladb.com/scylla/scylladb/amos-test/deb/debian/dists/jessie/scylladb-1.7/multiverse/binary-amd64/Packages.gz'
+        pkginfo_url: 'https://repositories.scylladb.com/scylla/scylladb/amos-test-debian8/deb/debian/dists/jessie/scylladb-1.7/multiverse/binary-amd64/Packages.gz'
         redirect_url: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/dists/jessie/scylladb-1.7/multiverse/binary-amd64/Packages.gz'
 
 host: ''


### PR DESCRIPTION
Commit d5116e64dbbf178b2fcbf7158d63b111a20d5200 introduced an issue, the uuid in pkg_info isn't updated together.