### PR TITLE
dump more log relate with scylla

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -191,6 +191,9 @@ def get_scylla_logs():
         process.run('sudo %s -f '
                     '-u scylla-io-setup.service '
                     '-u scylla-server.service '
+                    '-u scylla-ami-setup.service '
+                    '-u scylla-housekeeping-daily.service '
+                    '-u scylla-housekeeping-restart.service '
                     '-u scylla-jmx.service' % journalctl_cmd,
                     verbose=True, ignore_status=True)
     except path.CmdNotFoundError:


### PR DESCRIPTION
scylla-ami-setup.service only exists in ec2 AMI instance.
housekeeping error is also useful.

Currently if scylla-ami-setup has problem, artifact-test won't catch the error log.