### PR TITLE
ScyllaInstallGeneric: remove collectd verify

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -386,12 +386,9 @@ class ScyllaInstallGeneric(object):
         # verify io and sysconfig setup
         if self.is_systemd():
             process.run('systemctl status scylla-server')
-            process.run('systemctl status collectd')
             #process.run('systemctl status scylla-housekeeping-restart.timer')
         else:
             result = process.run('service scylla-server status')
-            assert 'running' in result.stdout
-            result = process.run('service collectd status')
             assert 'running' in result.stdout
 
 


### PR DESCRIPTION
Collectd was dropped from scylla package, so remove the status check of collectd.

Related commit: https://github.com/scylladb/scylla/commit/9971576ecb77abc228c4f11fb6271ccb4efb5e05