### PR TITLE
journalctl: dump the full log

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -188,7 +188,7 @@ class InstallPackageError(Exception):
 def get_scylla_logs():
     try:
         journalctl_cmd = path.find_command('journalctl')
-        process.run('sudo %s -f '
+        process.run('sudo %s -f --no-tail '
                     '-u scylla-io-setup.service '
                     '-u scylla-server.service '
                     '-u scylla-ami-setup.service '


### PR DESCRIPTION
Journalctl only shows last 10 lines by default in follow mode (-f). We need to
dump the full log. This patch added '--no-tail' option to show all lines even
in follow mode.

Problem: we can't see some scylla-ami-setup error, or early scylla_prepare error.
Bad example: http://jenkins.cloudius-systems.com:8080/job/scylla-master-ami-test/239/label=muninn/artifact/latest/job.log
Good example (test with this PR): http://jenkins.cloudius-systems.com:8080/job/scylla-staging-ami-test-clone/1/label=muninn/1/