### PR TITLE
adjust the scylla_setup timeout from 300 to 600

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -342,7 +342,7 @@ class ScyllaInstallGeneric(object):
             # fixme: current repoid and ruid aren't filled correctly by housekeeping backend
             # last_id = self.cvdb.get_last_id_v2("select * from housekeeping.checkversion where repoid='{}' and ruid='{}' and version like '{}%' and statuscode='i'".format(self.repoid, self.uuid, version))
             last_id = self.cvdb.get_last_id_v2("select * from housekeeping.checkversion where version like '{}%' and statuscode='i'".format(version))
-        process.run(setup_cmd, shell=True, verbose=True, timeout=300)
+        process.run(setup_cmd, shell=True, verbose=True, timeout=600)
         # check setup
         if self.uuid:
             # fixme: strict check with repoid, ruid


### PR DESCRIPTION
I saw scylla_setup takes more than 300 seconds in good artifact-test,
let's adjust the timeout to 600.