### PR TITLE
detect network device name before setup

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -318,7 +318,10 @@ class ScyllaInstallGeneric(object):
             assert self.cvdb.check_new_record(self.uuid, self.repoid, self.version, last_id, table='housekeeping.repodownload', add_filter="and file_name like 'scylla%server%{}%'".format(version))
 
         # enable raid setup when second disk exists
-        setup_cmd = '/usr/lib/scylla/scylla_setup --nic eth0'
+        result = process.run('ip -o link show', shell=True, verbose=True)
+        result = process.run('ip -o link show |grep ether |awk -F": " \'{print $2}\'', shell=True, verbose=True)
+        devname = result.stdout.strip()
+        setup_cmd = '/usr/lib/scylla/scylla_setup --nic %s' % devname
         result = process.run('ls /dev/[hvs]db', shell=True, ignore_status=True)
         devlist = result.stdout.split()
 


### PR DESCRIPTION
On ubuntu 18.04 & debian 9, the Enternet network device name is `ens0`.
The hardcode name doesn't work.