### PR TITLE
use java 1.8 on ubuntu 18.04

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -488,6 +488,7 @@ class ScyllaInstallUbuntu1804(ScyllaInstallDebian):
         self.download_scylla_repo()
         self.prepare_extend_repo()
         process.run('sudo apt-get update')
+        self.install_java18()
         self.sw_manager.upgrade()
         return [self.scylla_pkg()]
 


### PR DESCRIPTION
scylla-jmx doesn't work with latest jdk.
related issue: https://github.com/scylladb/scylla/issues/3858