### PR TITLE
Adding parameter timeout for waiting cluster up

### DIFF
--- a/scylla-artifacts.py.data/scylla-docker.yaml
+++ b/scylla-artifacts.py.data/scylla-docker.yaml
@@ -1,3 +1,4 @@
 # Docker
 docker_image: scylladb/scylla-nightly:latest
 node_cnt: 2
+start_timeout: 30

--- a/scylla_docker.py
+++ b/scylla_docker.py
@@ -160,7 +160,7 @@ class ScyllaDocker(object):
                 try:
                     res = line.split(':')
                     key = res[0].strip()
-                    val = res[1].split()[0].strip() if key != 'Total operation time' else\
+                    val = res[1].split()[0].strip().replace(',', '') if key != 'Total operation time' else\
                         ':'.join([res[1], res[2], res[3]]).strip()
                     results[key] = float(val) if val != 'NaN' and key != 'Total operation time' else val
                 except Exception as ex:


### PR DESCRIPTION
If host is busy or slow, scylla in docker container start slowly
and tests in scylla_docker.py are failed by timeout which is 30
Addint to configuration and possiblity to customize this timeout:
- in yaml file scylla-docker.yaml 'timeupwait'
- adding parameter to ScyllaDocker

Addintionally, tests failed due error on parsing output:
> Op rate                   :   18,589 op/s  [READ: 18,589 op/s]
> Partition rate            :   18,589 pk/s  [READ: 18,589 pk/s]

with exception
_ERROR| Failed parsing stress results: Op rate:   11,779 op/s  [WRITE: 11,779 op/s], error: invalid literal for float(): 11,779_
Adding code to cut the ',' from parsed value.