### PR TITLE
Scylla docker fix

### DIFF
--- a/scylla_docker.py
+++ b/scylla_docker.py
@@ -46,7 +46,8 @@ class ScyllaDocker(object):
     def clean_old_images(self):
         images = self._cmd('images -f "dangling=true" -q')
         if images:
-            self._cmd('rmi {}'.format(images), timeout=90)
+            images_str = ' '.join(images.split())
+            self._cmd('rmi "{}"'.format(images_str), timeout=90)
 
     def update_image(self):
         log.debug('update scylla image')

--- a/scylla_docker.py
+++ b/scylla_docker.py
@@ -91,6 +91,7 @@ class ScyllaDocker(object):
             time.sleep(2)
             try_cnt += 1
         if not self.wait_for_cluster_up():
+            self.destroy_cluster()
             raise Exception('Failed to start cluster: timeout expired.')
         return self.nodes
 


### PR DESCRIPTION
Clean cluster if cluster isn't up.

Tested PR in muninn:
```
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
JOB HTML   : /root/avocado/job-results/job-2018-11-29T14.16-41fca17/html/results.html
TESTS TIME : 387.40 s
avocado.test: Test results available in /root/avocado/job-results/job-2018-11-29T14.16-41fca17
```