### PR TITLE
journalctl: wrap time of since argument

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -212,7 +212,7 @@ class ScyllaServiceManager(object):
         srv_manager = service.ServiceManager()
         try:
             journalctl_cmd = path.find_command('journalctl')
-            timestamp = '--since %s' % self.start_time if self.start_time else ''
+            timestamp = '--since "%s"' % self.start_time if self.start_time else ''
             result = process.run('sudo %s --no-tail '
                                  '-u scylla-io-setup.service '
                                  '-u scylla-server.service '


### PR DESCRIPTION
Current:
$ journalctl .... --since 2018-12-25 07:29:05
  Failed to add match '07:29:05': Invalid argument
  Failed to add filters: Invalid argument