### PR TITLE
fix source issue of debian 8

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -495,7 +495,8 @@ class ScyllaInstallUbuntu1804(ScyllaInstallDebian):
 
 class ScyllaInstallDebian8(ScyllaInstallDebian):
     def prepare_extend_repo(self):
-        process.run("echo 'deb http://http.debian.net/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list", shell=True)
+        process.run("echo 'deb http://archive.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list", shell=True)
+        process.run("echo 'Acquire::Check-Valid-Until \"false\";' > /etc/apt/apt.conf.d/99jessie-backports", shell=True)
         process.run("apt-get install gnupg-curl -y")
         process.run("apt-key adv --fetch-keys https://download.opensuse.org/repositories/home:/scylladb:/scylla-3rdparty-jessie/Debian_8.0/Release.key")
         process.run("sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 17723034C56D4B19")

--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -494,6 +494,10 @@ class ScyllaInstallUbuntu1804(ScyllaInstallDebian):
 
 
 class ScyllaInstallDebian8(ScyllaInstallDebian):
+    def __init__(self, sw_repo):
+        process.run("sed -i -e 's/jessie-updates/stable-updates/g' /etc/apt/sources.list", shell=True)
+        super(ScyllaInstallDebian8, self).__init__(sw_repo)
+
     def prepare_extend_repo(self):
         process.run("echo 'deb http://archive.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list", shell=True)
         process.run("echo 'Acquire::Check-Valid-Until \"false\";' > /etc/apt/apt.conf.d/99jessie-backports", shell=True)


### PR DESCRIPTION
`jessie-backports` `jessie-updates` had been removed from debian source,
apt-get update / upgrade will fail.

reference:
- https://wiki.debian.org/LTS/Using
- https://wiki.debian.org/StableUpdates