### PR TITLE
scylla_docker: ignore empty line in c-s summary

### DIFF
--- a/scylla_docker.py
+++ b/scylla_docker.py
@@ -158,7 +158,7 @@ class ScyllaDocker(object):
                 continue
             elif line.startswith('END'):
                 break
-            if start:
+            if start and line.strip():
                 try:
                     res = line.split(':')
                     key = res[0].strip()


### PR DESCRIPTION
Handle a case when c-s summary contain empty line. latest c-s version 3.11
changed its output.

Fixes #123