### PR TITLE
support new distros - ubuntu1804 and debian9

### DIFF
--- a/scylla_private_repo.py
+++ b/scylla_private_repo.py
@@ -69,9 +69,9 @@ class ScyllaPrivateRepoSanity(Test):
         pkginfo_url = self.params.get('pkginfo_url')
         redirect_url = self.params.get('redirect_url')
         name = self.params.get('name', default='centos7')
-        if name in ['centos7']:
+        if 'centos' in name or 'rhel' in name:
             self.private_repo = RHELPrivateRepo(sw_repo, pkginfo_url, redirect_url)
-        elif name in ['ubuntu1404', 'ubuntu1604', 'debian8']:
+        elif 'ubuntu' in name or 'debian' in name:
             self.private_repo = DebianPrivateRepo(sw_repo, pkginfo_url, redirect_url)
         self.cvdb = CheckVersionDB(self.params.get('host'),
                                    self.params.get('user'),


### PR DESCRIPTION
I just added `2019.1` test to http://jenkins.scylladb.com/job/scylla-enterprise-private-repo-test/, but job failed for new supported distros in 2019.1 (ubuntu1804 & debian9)