### PR TITLE
Updated project requirements

### DIFF
--- a/install-prereqs.sh
+++ b/install-prereqs.sh
@@ -1,4 +1,4 @@
-yum install -y epel-release libvirt libvirt-devel pkgconfig gcc
+yum install -y epel-release libvirt libvirt-devel pkgconfig gcc git python-devel
 yum install -y python-pip
 pip install --upgrade pip
 pip install https://github.com/amoskong/avocado-ec2.git

--- a/requirements-python.txt
+++ b/requirements-python.txt
@@ -4,7 +4,7 @@ fabric==2.4.0
 ## multiplexer (avocado.core.tree)
 PyYAML==3.13
 ## vm plugin (avocado.core.plugins.vm)
-libvirt-python==4.9.0
+libvirt-python==5.3.0
 ## .tar.xz support (avocado.utils.archive)
 #pyliblzma>=0.5.3
 ## HTML report plugin (avocado.core.plugins.htmlresult)


### PR DESCRIPTION
added `git` and `python-devel` to prereqs
Errors that had when creating Docker container:
```
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Collecting https://github.com/amoskong/avocado-ec2.git
  Downloading https://github.com/amoskong/avocado-ec2.git
  ERROR: Cannot unpack file /tmp/pip-unpack-Osy7yh/avocado-ec2.git (downloaded from /tmp/pip-req-build-C3ceum, content-type: text/html; charset=utf-8); cannot detect archive format
ERROR: Cannot determine archive format of /tmp/pip-req-build-C3ceum
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Collecting git+https://github.com/amoskong/avocado-ec2.git@branch-scylladb
  Cloning https://github.com/amoskong/avocado-ec2.git (to revision branch-scylladb) to /tmp/pip-req-build-fO5aLv
  Running command git clone -q https://github.com/amoskong/avocado-ec2.git /tmp/pip-req-build-fO5aLv
  ERROR: Error [Errno 2] No such file or directory while executing command git clone -q https://github.com/amoskong/avocado-ec2.git /tmp/pip-req-build-fO5aLv
ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?
```