### PR TITLE
update scylla_prepare/irq setting error

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -225,7 +225,7 @@ class ScyllaServiceManager(object):
         except path.CmdNotFoundError:
             result = process.run('cat /var/log/syslog | grep scylla', shell=True,
                                  ignore_status=True)
-        error_list = ['I/O Scheduler is not properly configured!', 'Failed to start Scylla Server', 'Failed to write into /proc/irq']
+        error_list = ['I/O Scheduler is not properly configured!', 'Failed to start Scylla Server', 'failed to write into /proc/irq']
         for err in error_list:
             if err in result.stdout:
                 raise StartServiceError('Fail to start scylla-server, err: %s' % err)


### PR DESCRIPTION
Original error:
  scylla_prepare[13698]: Failed to write into /proc/irq/333/smp_affinity:
  (<class 'OSError'>, OSError(5, 'Input/output error'), <traceback object at 0x7f636fffeec8>)

New error format:
  scylla_prepare[15588]: Setting mask 00000001 in /proc/irq/90/smp_affinity:
  failed to write into /proc/irq/90/smp_affinity:
  (<class 'OSError'>, OSError(5, 'Input/output error'), <traceback object at 0x7fb07bb15048>)

Related old issue: https://github.com/scylladb/scylla-artifact-tests/issues/118