### PR TITLE
Revert "use java 1.8 on ubuntu 18.04"

### DIFF
--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -488,7 +488,6 @@ class ScyllaInstallUbuntu1804(ScyllaInstallDebian):
         self.download_scylla_repo()
         self.prepare_extend_repo()
         process.run('sudo apt-get update')
-        self.install_java18()
         self.sw_manager.upgrade()
         return [self.scylla_pkg()]
 


### PR DESCRIPTION
This reverts commit c163409ee5849fff2bc6453fe70eb8bbca4d32fc.

The openjdk dependency of scylla-tools-java had been changed from
default-jre-headless to openjdk-8-jre-headless, then openjdk-8 (Java 1.8)
will be installed during scylla installation.

Let's revert this commit, and make sure dependency is installed successfully.
Otherwise, some bug might be hidden.