### PR TITLE
refix clean of multiple old images

### DIFF
--- a/scylla_docker.py
+++ b/scylla_docker.py
@@ -47,7 +47,7 @@ class ScyllaDocker(object):
         images = self._cmd('images -f "dangling=true" -q')
         if images:
             images_str = ' '.join(images.split())
-            self._cmd('rmi "{}"'.format(images_str), timeout=90)
+            self._cmd('rmi {}'.format(images_str), timeout=90)
 
     def update_image(self):
         log.debug('update scylla image')


### PR DESCRIPTION
In latest test, the docker images parameter should not be included by double
quotation mark.

[amos@amos-centos7 ~]$ docker --version
Docker version 19.03.2, build 6a30dfc

[amos@amos-centos7 ~]$ docker images -f "dangling=true" -q
19c06d75f7f1
a8468ecc3d6c
[amos@amos-centos7 ~]$ docker rmi "19c06d75f7f1 a8468ecc3d6c"
Error response from daemon: invalid reference format
[amos@amos-centos7 ~]$ docker rmi --help

Usage:	docker rmi [OPTIONS] IMAGE [IMAGE...]

Remove one or more images

Options:
  -f, --force      Force removal of the image
      --no-prune   Do not delete untagged parents
[amos@amos-centos7 ~]$ docker rmi 19c06d75f7f1 a8468ecc3d6c
Deleted: sha256:a8468ecc3d6cfca1ff3274319990ae9f81c2fea078a060f15e38bae2d02ffcc8
Deleted: sha256:ec8a6aad2b31819afbda51b41301b4021c147324f08f569c1e76e4bf3e558d12