### PR TITLE
centos8: support to run artifact-test with docker

### DIFF
--- a/docker/env/Dockerfile_centos8
+++ b/docker/env/Dockerfile_centos8
@@ -1,0 +1,11 @@
+FROM centos:8
+
+ADD avocado-requirements.txt avocado-requirements.txt
+RUN yum install epel-release -y
+RUN yum update -y
+RUN yum install -y sudo gcc openssl-devel python2-devel xz-devel python2-pip libvirt libvirt-devel pkgconfig gdb-gdbserver git
+RUN pip2 install -r avocado-requirements.txt
+RUN pip2 install avocado-framework==36.4
+ADD requirements-python.txt requirements-python.txt
+RUN pip2 install setuptools==40.8.0
+RUN grep -v '^#' requirements-python.txt | xargs -t -L 1 pip2 install

--- a/docker/env/avocado-requirements.txt
+++ b/docker/env/avocado-requirements.txt
@@ -1,0 +1,22 @@
+# Avocado functional requirements
+# SSH lib (avocado.utils.remote)
+fabric==1.11.3
+# multiplexer (avocado.core.tree)
+PyYAML==3.11
+# vm plugin (avocado.core.plugins.vm)
+libvirt-python==1.2.9
+# .tar.xz support (avocado.utils.archive)
+pyliblzma==0.5.3
+# HTML report plugin (avocado.core.plugins.htmlresult)
+pystache==0.5.3
+# REST client (avocado.core.restclient)
+requests==1.2.3
+# stevedore for loading "new style" plugins
+stevedore==1.8.0; python_version >= '2.7'
+# stevedore-1.11.0 won't support python2.6 anymore
+stevedore==1.8.0,<=1.10.0; python_version < '2.7'
+# Additional python 2.6 specific requirements for avocado and unittests (backports)
+argparse==1.3.0; python_version < '2.7'
+logutils==0.3.3; python_version < '2.7'
+importlib==1.0.3; python_version < '2.7'
+unittest2==1.0.0; python_version < '2.7'

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,16 @@
+
+WORKSPACE=`pwd`
+WORK_DIR='/workdir'
+
+docker run -v $WORKSPACE:/workdir \
+    --privileged \
+    -v /var/run:/run \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+    -v /tmp:/tmp \
+    -v /var/tmp:/var/tmp \
+    -v ${HOME}:${HOME} \
+    -v /etc/passwd:/etc/passwd:ro \
+    -v /etc/group:/etc/group:ro \
+    -w ${WORK_DIR} \
+    --network host\
+    $@  # {image} {avocado cmdline}

--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -558,6 +558,12 @@ class ScyllaInstallCentOS(ScyllaInstallGeneric):
         self.sw_manager.remove('boost-system')
         self.sw_manager.remove('abrt')
 
+    def env_setup(self):
+        self._centos_remove_system_packages()
+        self.download_scylla_repo()
+        self.sw_manager.upgrade()
+        return [self.scylla_pkg()]
+
     def scylla_pkg(self):
         """
         Get package name, compat both of scylla and scylla-enterprise.
@@ -566,15 +572,6 @@ class ScyllaInstallCentOS(ScyllaInstallGeneric):
             result = process.run('sudo yum search scylla-enterprise')
             self.is_enterprise = True if 'scylla-enterprise.x86_64' in result.stdout else False
         return 'scylla-enterprise' if self.is_enterprise else 'scylla'
-
-
-class ScyllaInstallCentOS7(ScyllaInstallCentOS):
-
-    def env_setup(self):
-        self._centos_remove_system_packages()
-        self.download_scylla_repo()
-        self.sw_manager.upgrade()
-        return [self.scylla_pkg()]
 
 
 class ScyllaInstallAMI(ScyllaInstallGeneric):
@@ -717,6 +714,8 @@ class ScyllaArtifactSanity(Test):
                      detected_distro.version == '10')
         centos_7 = (detected_distro.name.lower() in ['centos', 'redhat'] and
                     detected_distro.version == '7')
+        centos_8 = (detected_distro.name.lower() in ['centos', 'redhat'] and
+                    detected_distro.version == '8')
 
         installer = None
 
@@ -745,7 +744,9 @@ class ScyllaArtifactSanity(Test):
             installer = ScyllaInstallFedora22(sw_repo=sw_repo)
 
         elif centos_7:
-            installer = ScyllaInstallCentOS7(sw_repo=sw_repo)
+            installer = ScyllaInstallCentOS(sw_repo=sw_repo)
+        elif centos_8:
+            installer = ScyllaInstallCentOS(sw_repo=sw_repo)
 
         else:
             self.skip('Unsupported OS: %s' % detected_distro)

--- a/scylla-artifacts.py
+++ b/scylla-artifacts.py
@@ -390,8 +390,12 @@ class ScyllaInstallGeneric(object):
         # verify ntp
         if is_debian_variant:
             process.run('service ntp status')
-        else:
-            process.run('systemctl status ntpd')
+        elif distro_name in ['centos', 'redhat']:
+            if distro_version == '7':
+                process.run('systemctl status ntpd')
+            else:
+                process.run('systemctl status chronyd')
+
         # verify coredump setup
         if self.is_systemd() and 'debian' not in distro_name:
             result = process.run('coredumpctl info', ignore_status=True)


### PR DESCRIPTION
Run artifact-test of Centos8 with docker, then we don't need to depend on VMs, it can be run on any machine.