### PR TITLE
docker: don't fail the test for exception in cleaning old images

### DIFF
--- a/scylla_docker.py
+++ b/scylla_docker.py
@@ -52,7 +52,10 @@ class ScyllaDocker(object):
     def update_image(self):
         log.debug('update scylla image')
         self._cmd('pull {}'.format(self._image), timeout=600)
-        self.clean_old_images()
+        try:
+            self.clean_old_images()
+        except Exception as ex:
+            log.debug(ex)
 
     def get_node_ip(self, node_name):
         out = self._cmd("inspect --format='{{{{ .NetworkSettings.IPAddress }}}}' {}".format(node_name))


### PR DESCRIPTION
Some test failed and left stopped container, their images won't be
deleted directly. We can't forcely clean them in scylla docker test,
and our test should continue.

Fixes #140 